### PR TITLE
cmake_minimum_required updated to 4.0 in CMakeLists.txt 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 4.0)
+cmake_minimum_required(VERSION 3.10)
 project(pybrg)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/pybind11)
 pybind11_add_module(pybrg ./src/wrapper_bindings.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 4.0)
 project(pybrg)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/pybind11)
 pybind11_add_module(pybrg ./src/wrapper_bindings.cpp)


### PR DESCRIPTION
cmake_minimum_required updated to 4.0 in CMakeLists.txt  as values of …3.5 no longer supported for this flag, and support for <3.10 will be removed in future versions